### PR TITLE
Update documentation and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,22 @@ General steps done by this role to build the SSL profile:
 
 ## Prerequisites
 
-- Install [Python](https://www.python.org/downloads/) 3.9 or later
-- Install [ansible-core](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) from **2.15.0** to **2.17.x.** Avoid the `pipx` installation method
-- Install `ansible.netcommon` collection
-- Install `arista.eos` collection
+- Install [Python](https://www.python.org/downloads/) (Tested with Python 3.12.3)
+- Install [ansible-core](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) (Tested with ansible-core 2.17.4)
+- Install `scp` Python package (Tested with scp 0.15.0)
+- Install `ansible.netcommon` collection (Tested with ansible.netcommon 7.1.0)
+- Install `arista.eos` collection (Tested with arista.eos 10.0.0)
 - Network access from the Ansible control node to both AGNI service and EOS devices
 - EOS devices must have `aaa authorization exec default` configured for SCP to work
+- Ensure you have a properly configured [Ansible inventory file](https://docs.ansible.com/ansible/latest/inventory_guide/intro_inventory.html) that defines the target EOS devices
 
-Note: This role **must** uses `network_cli` connection type and `paramiko` SSH type. These settings are pre-configured in the role's vars:
+📝 **Note:** This role **must** uses `network_cli` connection type and `paramiko` SSH type. These settings are pre-configured in the role's vars:
 ```yaml
 ansible_connection: network_cli
 ansible_network_os: eos
 ansible_network_cli_ssh_type: paramiko
 ```
+⚠️ **Warning:** This role will **overwrite** any existing AGNI SSL profile, private key, and certificates if they already exist on the device. Please ensure this is acceptable before proceeding.
 
 ## Installation
 To use this role, you need to download it from GitHub and place it in a location where Ansible can find it. Here are the steps:
@@ -50,13 +53,17 @@ git clone https://github.com/carl-baillargeon/eos_agni_radsec.git
 roles_path = roles
 ```
 
+More details on storing and finding Ansible roles can be found in the [Ansible documentation](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html#storing-and-finding-roles).
+
 ## Running the Playbook
 
 To run the playbook that uses this role:
 
 1. Ensure you have set the required environment variables as described in the [Environment Variables](#environment-variables) section.
 
-2. Create a playbook file (e.g., `configure_agni_radsec.yml`) with the content as shown in the [Example](#example) section. **Don't forget to provide the appropriate CSR information.**
+2. Create a playbook file (e.g., `configure_agni_radsec.yml`) with the content as shown in the [Example](#example) section.
+
+    ⚠️ **Important:** Don't forget to provide the appropriate CSR information.
 
 3. Run the playbook using the following command:
 ```bash
@@ -64,18 +71,18 @@ ansible-playbook configure_agni_radsec.yml -i your_inventory_file
 ```
 Replace `your_inventory_file` with the path to your Ansible inventory file.
 
-1. If you need to pass additional variables or override defaults, you can use the `-e` option:
+4. If you need to pass additional variables or override defaults, you can use the `-e` option:
 ```bash
 ansible-playbook configure_agni_radsec.yml -i your_inventory_file -e "agni_base_url=https://your-agni-url.com"
 ```
 Remember to ensure that your Ansible control node has network access to both the AGNI service and your EOS devices.
 
-## Example
+## Example Playbook
 
 ```yaml title="configure_agni_radsec.yml"
 ---
 - name: Configure SSL profile for AGNI RadSec on EOS Switches
-  hosts: GLOBAL # <-- Targeted devices
+  hosts: GLOBAL # <-- Targeted devices from the Ansible inventory
   gather_facts: no
   tasks:
     - name: Load and run the role eos_agni_radsec
@@ -89,7 +96,6 @@ Remember to ensure that your Ansible control node has network access to both the
           locality: "MTL"
           organization: "Home"
           organizational_unit: "Lab"
-          domain: "home.arpa"
 ```
 
 ## Input variables
@@ -122,7 +128,6 @@ eos_csr_info:
   locality: <str>
   organization: <str>
   organizational_unit: <str>
-  domain: <str>
 ```
 ## Environment Variables
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,6 @@
       - eos_csr_info.locality != ""
       - eos_csr_info.organization != ""
       - eos_csr_info.organizational_unit != ""
-      - eos_csr_info.domain != ""
     fail_msg: "One or more required CSR variables are not set."
 
 - name: Gather EOS facts
@@ -40,9 +39,9 @@
   ansible.builtin.uri:
     url: "{{ agni_base_url }}/cvcue/keyLogin?keyID={{ lookup('env', 'AGNI_KEY_ID') }}&keyValue={{ lookup('env', 'AGNI_KEY_VALUE') }}&casURL=%3Cstring%3E"
     method: GET
-    return_content: true
     headers:
-      Accept: "application/json"
+      Accept: application/json
+    return_content: true
   register: auth_response
   until: auth_response.status == 200
   retries: 10
@@ -62,7 +61,6 @@
     method: POST
     headers:
       Accept: application/json
-      Content-Type: application/json
       Cookie: "{{ auth_cookie }}"
     return_content: true
   register: api_response
@@ -80,35 +78,26 @@
   delegate_to: localhost
   run_once: true
 
-- name: Check if AGNI RadSec CA Certificate and private key exist
-  arista.eos.eos_command:
-    commands:
-      - show management security ssl certificate {{ radsec_ca_certificate }}.{{ radsec_ca_certificate_format }} | json
-      - show management security ssl key {{ eos_private_key }} | json
-  register: cert_key_check
-
 - name: Copy the AGNI RadSec CA Certificate to the switch
   ansible.netcommon.net_put:
     src: "{{ temp_path }}/{{ radsec_ca_certificate }}.{{ radsec_ca_certificate_format }}"
     dest: "{{ eos_cert_path }}/{{ radsec_ca_certificate }}.{{ radsec_ca_certificate_format }}"
-  when: not cert_key_check.stdout_lines[0].certificates
 
 - name: Generate the AGNI RadSec private key
   arista.eos.eos_command:
     commands: security pki key generate rsa 2048 {{ eos_private_key }}
-  when: not cert_key_check.stdout_lines[1].publicKeys
 
 - name: Generate the CSR for AGNI
   arista.eos.eos_command:
     commands: >
       security pki certificate generate signing-request key {{ eos_private_key }} parameters
-      common-name "{{ show_version.stdout_lines.0.systemMacAddress }}"
-      country "{{ eos_csr_info.country }}"
-      state "{{ eos_csr_info.state }}"
-      locality "{{ eos_csr_info.locality }}"
-      organization "{{ eos_csr_info.organization }}"
-      organization-unit "{{ eos_csr_info.organizational_unit }}"
-      subject-alternative-name dns {{ inventory_hostname }}.{{ eos_csr_info.domain }}
+      common-name {{ show_version.stdout_lines.0.systemMacAddress }}
+      country {{ eos_csr_info.country }}
+      state {{ eos_csr_info.state }}
+      locality {{ eos_csr_info.locality }}
+      organization {{ eos_csr_info.organization }}
+      organization-unit {{ eos_csr_info.organizational_unit }}
+      subject-alternative-name dns {{ ansible_net_hostname }}
   register: csr_output
 
 - name: Send the CSR to AGNI and return the signed certificate
@@ -117,17 +106,13 @@
     method: POST
     headers:
       Accept: application/json
-      Content-Type: application/json
       Cookie: "{{ auth_cookie }}"
       X-AGNI-ORG-ID: "{{ lookup('env', 'AGNI_ORG_ID') }}"
+    # body_format sets the Content-Type header accordingly
     body_format: json
     body:
       csr: "{{ csr_output.stdout[0] | regex_replace('\\n$', '') }}"
-      dnsnames:
-        - "{{ inventory_hostname }}.{{ eos_csr_info.domain }}"
-      nadID: 0
       orgID: "{{ lookup('env', 'AGNI_ORG_ID') }}"
-      password: ""
   register: signed_cert_response
   until: signed_cert_response.status == 200
   retries: 10
@@ -143,13 +128,13 @@
 - name: Save the signed certificate to a temporary file
   ansible.builtin.copy:
     content: "{{ signed_cert_response.json.data.x509Certificate }}"
-    dest: "{{ temp_path }}/{{ inventory_hostname }}.{{ eos_csr_info.domain }}.crt"
+    dest: "{{ temp_path }}/{{ ansible_net_hostname }}.crt"
     mode: "0644"
 
 - name: Copy the signed certificate to the switch
   ansible.netcommon.net_put:
-    src: "{{ temp_path }}/{{ inventory_hostname }}.{{ eos_csr_info.domain }}.crt"
-    dest: "{{ eos_cert_path }}/{{ inventory_hostname }}.{{ eos_csr_info.domain }}.crt"
+    src: "{{ temp_path }}/{{ ansible_net_hostname }}.crt"
+    dest: "{{ eos_cert_path }}/{{ ansible_net_hostname }}.crt"
 
 - name: Delete the temporary AGNI RadSec CA Certificate file
   ansible.builtin.file:
@@ -160,18 +145,18 @@
 
 - name: Delete the temporary signed certificate file
   ansible.builtin.file:
-    path: "{{ temp_path }}/{{ inventory_hostname }}.{{ eos_csr_info.domain }}.crt"
+    path: "{{ temp_path }}/{{ ansible_net_hostname }}.crt"
     state: absent
 
 - name: Configure the SSL profile for AGNI RadSec
   arista.eos.command:
     commands:
-      - "copy flash:{{ inventory_hostname }}.{{ eos_csr_info.domain }}.crt certificate:"
+      - "copy flash:{{ ansible_net_hostname }}.crt certificate:"
       - "copy flash:{{ radsec_ca_certificate }}.{{ radsec_ca_certificate_format }} certificate:"
       - "configure"
       - "management security"
       - "ssl profile {{ eos_ssl_profile }}"
-      - "certificate {{ inventory_hostname }}.{{ eos_csr_info.domain }}.crt key {{ eos_private_key }}"
+      - "certificate {{ ansible_net_hostname }}.crt key {{ eos_private_key }}"
 
 - name: Get the SSL profile configuration
   arista.eos.eos_command:


### PR DESCRIPTION
- Update documentation
- Update tasks to use `ansible_net_hostname` instead of `inventory_hostname` to have the proper device hostname in the certificate