### PR TITLE
Added a task to add switches to AGNI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@
 
 General steps done by this role to build the SSL profile:
 
-1. Pull the AGNI RadSec CA Certificate 
-2. Generate a private key and CSR on EOS
-3. Send the CSR to AGNI and get a signed client certificate
-4. Copy both certificates to EOS
-5. Configure the SSL profile using the previous certificates/key
-6. Validate the SSL profile
+1. Add switch to Devices in AGNI
+2. Pull the AGNI RadSec CA Certificate 
+3. Generate a private key and CSR on EOS
+4. Send the CSR to AGNI and get a signed client certificate
+5. Copy both certificates to EOS
+6. Configure the SSL profile using the previous certificates/key
+7. Validate the SSL profile
 
 ## Roadmap
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,8 +32,8 @@
 - name: Validate EOS SCP configuration
   assert:
     that:
-      - "'aaa authorization exec default' in ansible_net_config"
-    msg: "'aaa authorization exec default' is not configured on the switch and is required for SCP to work on EOS"
+      - "'aaa authorization exec default local' in ansible_net_config"
+    msg: "'aaa authorization exec default local' is not configured on the switch and is required for SCP to work on EOS"
 
 - name: Authenticate to AGNI and generate API cookies
   ansible.builtin.uri:
@@ -54,6 +54,68 @@
     auth_cookie: "{{ auth_response.cookies | dict2items | map(attribute='key') | zip(auth_response.cookies | dict2items | map(attribute='value')) | map('join', '=') | join(',') }}"
   delegate_to: localhost
   run_once: true
+  
+
+- name: Add NAD to AGNI
+  ansible.builtin.uri:
+    url: "{{ agni_base_url }}/api/config.nad.add"
+    method: POST
+    headers:
+      Accept: application/json
+      Cookie: "{{ auth_cookie }}"
+    body_format: json
+    body:
+      orgID: "{{ lookup('env', 'AGNI_ORG_ID') }}"
+      vendor: "arista-switch"
+      serialNumber: "{{ show_version.stdout[0].serialNumber }}"
+      mac: "{{ show_version.stdout[0].systemMacAddress }}"
+      ipAddress: "{{ ansible_host }}"
+      name: "{{ inventory_hostname }}"
+    return_content: true
+  register: nad_response
+  until: nad_response.status == 200
+  retries: 10
+  delay: 2
+
+- name: List NAD in AGNI
+  ansible.builtin.uri:
+    url: "{{ agni_base_url }}/api/config.nad.list"
+    method: POST
+    headers:
+      Accept: application/json
+      Cookie: "{{ auth_cookie }}"
+    body_format: json
+    body:
+      orgID: "{{ lookup('env', 'AGNI_ORG_ID') }}"
+    return_content: true
+  register: nad_response
+  until: nad_response.status == 200
+  retries: 10
+  delay: 2
+  delegate_to: localhost
+  run_once: true
+#
+#- name: Delete NAD from AGNI
+#  ansible.builtin.uri:
+#    url: "{{ agni_base_url }}/api/config.nad.delete"
+#    method: POST
+#    headers:
+#      Accept: application/json
+#      Cookie: "{{ auth_cookie }}"
+#    body_format: json
+#    body:
+#      orgID: "{{ lookup('env', 'AGNI_ORG_ID') }}"
+#      #mac: show_version.stdout[0].systemMacAddress| replace(':', '')
+#      name: "{{ inventory_hostname }}"
+#    return_content: true
+#  register: nad_response
+#  until: nad_response.status == 200
+#  retries: 10
+#  delay: 2
+#
+- debug:
+    var: nad_response
+
 
 - name: Retrieve AGNI RadSec CA Certificate
   ansible.builtin.uri:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -88,34 +88,19 @@
     body:
       orgID: "{{ lookup('env', 'AGNI_ORG_ID') }}"
     return_content: true
-  register: nad_response
-  until: nad_response.status == 200
+  register: nad_list_response
+  until: nad_list_response.status == 200
   retries: 10
   delay: 2
   delegate_to: localhost
   run_once: true
-#
-#- name: Delete NAD from AGNI
-#  ansible.builtin.uri:
-#    url: "{{ agni_base_url }}/api/config.nad.delete"
-#    method: POST
-#    headers:
-#      Accept: application/json
-#      Cookie: "{{ auth_cookie }}"
-#    body_format: json
-#    body:
-#      orgID: "{{ lookup('env', 'AGNI_ORG_ID') }}"
-#      #mac: show_version.stdout[0].systemMacAddress| replace(':', '')
-#      name: "{{ inventory_hostname }}"
-#    return_content: true
-#  register: nad_response
-#  until: nad_response.status == 200
-#  retries: 10
-#  delay: 2
-#
-- debug:
-    var: nad_response
 
+- name: Validate the NAD was created or exists
+  assert:
+    that:
+      - nad_list_response.json.data.nads | selectattr('name', 'equalto', inventory_hostname) | list | length > 0
+    fail_msg: "Switch is not defined in AGNI: {{ inventory_hostname }}"
+    success_msg: "Switch exists in AGNI"
 
 - name: Retrieve AGNI RadSec CA Certificate
   ansible.builtin.uri:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,8 +32,8 @@
 - name: Validate EOS SCP configuration
   assert:
     that:
-      - "'aaa authorization exec default local' in ansible_net_config"
-    msg: "'aaa authorization exec default local' is not configured on the switch and is required for SCP to work on EOS"
+      - "'aaa authorization exec default' in ansible_net_config"
+    msg: "'aaa authorization exec default' is not configured on the switch and is required for SCP to work on EOS"
 
 - name: Authenticate to AGNI and generate API cookies
   ansible.builtin.uri:


### PR DESCRIPTION
If you think it is useful I have added a task to add the switches to AGNI and an assertion to check if they were added correctly. Since I am onboarding a large number of switches it works for my use case.

Which looks like this:

`- name: Add NAD to AGNI
  ansible.builtin.uri:
    url: "{{ agni_base_url }}/api/config.nad.add"
    method: POST
    headers:
      Accept: application/json
      Cookie: "{{ auth_cookie }}"
    body_format: json
    body:
      orgID: "{{ lookup('env', 'AGNI_ORG_ID') }}"
      vendor: "arista-switch"
      serialNumber: "{{ show_version.stdout[0].serialNumber }}"
      mac: "{{ show_version.stdout[0].systemMacAddress }}"
      ipAddress: "{{ ansible_host }}"
      name: "{{ inventory_hostname }}"
    return_content: true
  register: nad_response
  until: nad_response.status == 200
  retries: 10
  delay: 2

- name: List NAD in AGNI
  ansible.builtin.uri:
    url: "{{ agni_base_url }}/api/config.nad.list"
    method: POST
    headers:
      Accept: application/json
      Cookie: "{{ auth_cookie }}"
    body_format: json
    body:
      orgID: "{{ lookup('env', 'AGNI_ORG_ID') }}"
    return_content: true
  register: nad_list_response
  until: nad_list_response.status == 200
  retries: 10
  delay: 2
  delegate_to: localhost
  run_once: true

- name: Validate the NAD was created or exists
  assert:
    that:
      - nad_list_response.json.data.nads | selectattr('name', 'equalto', inventory_hostname) | list | length > 0
    fail_msg: "Switch is not defined in AGNI: {{ inventory_hostname }}"
    success_msg: "Switch exists in AGNI"`



